### PR TITLE
Delete extra spaces and repeated phrase

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,10 +64,10 @@
 		<div id="Subcontent">
 			<h2>Home</h2>
 
-			<p>Ixion is a  UK based <a href="http://ixiemaster.ixion.org.uk/cgi-bin/mailman/listinfo/ixion">mailing list</a> for those interested in motorcycling.   It has been likened to "a group of bikers chatting down the pub".</p>
-<p>Ixion was originally set up by <a href="http://david.edmondson.com/">Dave Edmondson</a> in July 1990 in July 1990 at Queen  Mary and Westfield College in East London. Malcolm Jackson took over the  running of Ixion at the University of Nottingham in June 1993,  continuing until January 2002. <br/><br/>Since that time, the list has been hosted by Ixie-owned facilities,  moving servers again in April 2009 and most recently in March 2011,  whilst simultaneously undergoing a complete redesign.</p>
-<p>Originally called <strong>Ogri</strong>, the name was changed to <strong>Ixion</strong> in May 1996.</p>
 			
+			<p>Ixion is a UK based <a href="http://ixiemaster.ixion.org.uk/cgi-bin/mailman/listinfo/ixion">mailing list</a> for those interested in motorcycling. It has been likened to "a group of bikers chatting down the pub".</p>
+<p>Ixion was originally set up by <a href="http://david.edmondson.com/">Dave Edmondson</a> in July 1990 at Queen Mary and Westfield College in East London. Malcolm Jackson took over the running of Ixion at the University of Nottingham in June 1993, continuing until January 2002. <br/><br/>Since that time, the list has been hosted by Ixie-owned facilities, moving servers again in April 2009 and most recently in March 2011, whilst simultaneously undergoing a complete redesign.</p>
+<p>Originally called <strong>Ogri</strong>, the name was changed to <strong>Ixion</strong> in May 1996.</p>
 			
 		</div>
 	</div>


### PR DESCRIPTION
Double spaces between words, and a repeated phrase in body of page removed.
Also removed superfluous carriage return characters from ends of lines.