### PR TITLE
Delete superfluous carriage returns and link

### DIFF
--- a/events/index.html
+++ b/events/index.html
@@ -112,7 +112,7 @@
 
 			<p>Ixion isn't a 'club' nor an organisation, and as such, events tend to be organised by ixies who have either decided to do something, and other ixies have come along or, more commonly, said in passing something like "someone should organise such-and-such" or "why don't we go to so-and-so" and suddenly they're herding cats like no cat-herder has ever herded.</p>
 <p>So what can an ixie expect in terms of events?  There are several regular ones...</p>
-<p><a href="http://andyc600.co.uk/ixiesos.htm">SOS : Start of Season</a>. A weekend in sunny wales, usually in April, to herald in the start of the biking season: Hurrah!</p>
+<p><b>Start of Season</b>. A weekend in sunny wales, usually in April, to herald in the start of the biking season: Hurrah!</p>
 <p><a href="/events/contixion/">Contixion</a> : A motly crew of ixies descend on Normandy for an extended long weekend.  Sometimes in May, sometimes in June or July.  Always good fun.</p>
 <p><a href="/events/ixion-special/">Ixion Special</a> : We have the privilege of having our very own steam train for he day.  Train rides are had, some enjoy a trip on the footplate, followed by a lovely big BBQ and lashings and lashing of ginger ale..  No, sorry..  LOCAL ale...</p>
 <p><a href="/events/cadwell/">Cadwell</a> : For over ten years now, Ixies have been riding aroud in circles in Lincolnshire for two days. You'd think they'd know the way by now, but still they come.  And what a cracking two days it is.  <a href="/events/cadwell/cadwell-2010-review/">Read the review</a> of last year if you don't believe me.</p>


### PR DESCRIPTION
DOS to Unix changes: carriage returns on all lines deleted.
Link to andy600 removed to leave "Ixion SoS" line without a link because Andy's site no longer exists.